### PR TITLE
Update SDK and package dependencies

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "8.0.404"
+    "version": "8.0.411"
   }
 }

--- a/src/CloudflareSpeedTester/CloudflareSpeedTester.csproj
+++ b/src/CloudflareSpeedTester/CloudflareSpeedTester.csproj
@@ -13,15 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.50.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.12.19">
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
- Updated .NET SDK version in `global.json` from 8.0.404 to 8.0.411.
- Upgraded package dependencies in `CloudflareSpeedTester.csproj`:
  - CsvHelper: 33.0.1 → 33.1.0
  - Microsoft.Extensions.DependencyInjection: 9.0.0 → 9.0.6
  - Microsoft.Extensions.Http: 9.0.0 → 9.0.6
  - Spectre.Console.Cli: 0.49.1 → 0.50.0
  - Spectre.Console.Json: 0.49.1 → 0.50.0
  - Microsoft.VisualStudio.Threading.Analyzers: 17.12.19 → 17.14.15